### PR TITLE
Fixes for Call Logs and Triggers

### DIFF
--- a/whats_db_merge.sh
+++ b/whats_db_merge.sh
@@ -160,8 +160,12 @@ function CheckCommonCols() {
 
    case "${column_list[i]}" in
     *jid_row_id*|business_owner_jid|seller_jid|*lid_row_id*)
-    column_list_select[i]="j${i}.new_id"
-    column_list_str+=("left join jid_map77 j${i} on j${i}.old_id=x.${column_list[i]}")
+     if [[ "$2" == "call_log" || "$2" == "missed_call_logs" ]]; then
+      column_list_select[i]="coalesce(j${i}.new_id,0)"
+     else
+      column_list_select[i]="j${i}.new_id"
+     fi
+     column_list_str+=("left join jid_map77 j${i} on j${i}.old_id=x.${column_list[i]}")
    ;;
 
    *chat_row_id*)

--- a/whats_db_merge.sh
+++ b/whats_db_merge.sh
@@ -1,4 +1,4 @@
-#/!bin/bash
+#!/usr/bin/env bash
 
 ##here put the full paths to the databases in quotes. Multiple databases can be merged. As long as they have a recent schema. From 2022 or later
 
@@ -6,6 +6,7 @@ dbs=("path_to_db1" "path_to_db2")
 
 
 #we need to use the latest database as the schema for the merged database. To get the latest database we have to find the one with the newest timestamp. This method can be overridden by directly assigning the database you desire as the base_db variable
+#warning: directly assigning the wrong database can result in an output where this database data is duplicated, and not merged with the other
 
 db_time=()
 
@@ -317,7 +318,7 @@ fi
    
    CheckCommonCols "$db" "$table"
    if [[ -n "$common_columns" ]]; then
-    sqlite3 "$output" "attach '$db' as db;" "insert or ignore into ${table} (${common_columns}) select ${common_columns_str_select} from db.${table} x ${common_columns_str}${wherestr}${sortstr}" "create table if not exists ${table}_map77 (old_id integer unique, new_id integer unique);" "delete from ${table}_map77;" "insert or ignore into ${table}_map77 (old_id,new_id) ${mapjoin};"
+    sqlite3 "$output" "attach '$db' as db;" "insert or ignore into ${table} (${common_columns}) select ${common_columns_str_select} from db.${table} x ${common_columns_str}${wherestr}${sortstr};" "create table if not exists ${table}_map77 (old_id integer unique, new_id integer unique);" "delete from ${table}_map77;" "insert or ignore into ${table}_map77 (old_id,new_id) ${mapjoin};"
 
    else
     echo -e "no common columns found in table $table on database: $output and database: $db\nThis table will be skipped"
@@ -330,7 +331,7 @@ fi
   CheckCommonCols "$db" "$table"
   if [[ -n "$common_columns" ]]; then
  
-   sqlite3 "$output" "attach '$db' as db;" "insert or ignore into ${table} (${common_columns}) select ${common_columns_str_select} from db.${table} x ${common_columns_str}"
+   sqlite3 "$output" "attach '$db' as db;" "insert or ignore into ${table} (${common_columns}) select ${common_columns_str_select} from db.${table} x ${common_columns_str};"
    
    
    else


### PR DESCRIPTION
I noticed that my conversations contained multiple instances of “Call log was deleted” messages where there used to be actual call details (duration, etc.).

The row counts for call logs in the input and output databases didn’t add up. After checking the results of the SQL queries executed by the script, I found that the INSERT INTO … SELECT statements for call_log and missed_call_logs were violating NOT NULL constraints. The error was being suppressed by the OR IGNORE clause.

I was able to fix that using COALESCE.

---

While double-checking the input and output schemas, I also noticed that many triggers (about half) were missing from the output.

It turned out that the script assumes triggers are one-liners, so only those were successfully restored. That error, too, was silenced by 2>/dev/null.

I’ve fixed that as well.